### PR TITLE
Correct http to https

### DIFF
--- a/QGISDigitransitGeocoding/core/digitransit_geocoder_processing_plugin_algorithm.py
+++ b/QGISDigitransitGeocoding/core/digitransit_geocoder_processing_plugin_algorithm.py
@@ -780,7 +780,7 @@ class DigitransitGeocoderPluginAlgorithm(QgsProcessingAlgorithm):
                 address += row[index] + ","
             address = address.rstrip(",")
 
-            base_url = "http://api.digitransit.fi/geocoding/v1/search?"
+            base_url = "https://api.digitransit.fi/geocoding/v1/search?"
 
             hdr = {"digitransit-subscription-key": api_key}
 

--- a/QGISDigitransitGeocoding/ui/digitransit_geocoder_dockwidget.py
+++ b/QGISDigitransitGeocoding/ui/digitransit_geocoder_dockwidget.py
@@ -188,7 +188,7 @@ class DigitransitGeocoderDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
             )
 
     def geocode(self, search_text):
-        base_url = "http://api.digitransit.fi/geocoding/v1/search"
+        base_url = "https://api.digitransit.fi/geocoding/v1/search"
         api_key = bytes(
             QgsExpressionContextUtils.globalScope().variable("DIGITRANSIT_API_KEY"),
             "utf-8",


### PR DESCRIPTION
The http in the Digitransit API URL doesn't work anymore. Please, correct http to https.